### PR TITLE
[追加]Basic認証の環境変数

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
+
+  
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end
+

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -61,3 +61,5 @@
 #   }
 
 server '3.115.244.144', user: 'ec2-user', roles: %w{app db web}
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
#What
Basic認証の実装

#Why
作成するメルカリのコピーサイトの誤ってアクセスしたユーザーに誤解を生むことがないように、Basic認証を導入して閲覧できるユーザーを制限するため